### PR TITLE
middleware secret 설정을 NEXTAUTH_SECRET으로 통일

### DIFF
--- a/lib/authOptions.ts
+++ b/lib/authOptions.ts
@@ -48,19 +48,29 @@ export const authOptions: NextAuthOptions = {
     strategy: "jwt" as SessionStrategy,
   },
   jwt: {
-    secret: process.env.JWT_SECRET,
+    secret: process.env.NEXTAUTH_SECRET,
     maxAge: 30 * 24 * 60 * 60,
   },
+  secret: process.env.NEXTAUTH_SECRET,
   pages: {
     signIn: "/auth/login",
     error: "/auth/login",
   },
   callbacks: {
     async jwt({ token, user }: { token: JWT; user?: User }) {
-      return { ...token, ...user };
+      if (user) {
+        token.id = user.id;
+        token.name = user.name;
+        token.email = user.email;
+      }
+      return token;
     },
     async session({ session, token }: { session: Session; token: JWT }) {
-      session.user = token;
+      if (session.user) {
+        session.user.id = token.id as string;
+        session.user.name = token.name as string;
+        session.user.email = token.email as string;
+      }
       return session;
     },
   },

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -115,7 +115,6 @@ const ChatInput = ({
           className='hidden'
           ref={imageRef}
           onChange={(e) => {
-            console.log("파일 선택 이벤트 발생");
             previewImage(e, setImagePreview, setImage);
           }}
           accept='image/*'

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -4,7 +4,7 @@ import { NextRequest, NextResponse } from 'next/server';
 export { default } from 'next-auth/middleware';
 
 export async function middleware(req: NextRequest) {
-  const session = await getToken({ req, secret: process.env.JWT_SECRET });
+  const session = await getToken({ req, secret: process.env.NEXTAUTH_SECRET });
   const pathname = req.nextUrl.pathname;
 
   if (pathname.startsWith('/profile') && !session) {


### PR DESCRIPTION
## 📌 개요

- 로그인 후 세션이 유지되지 않고 /auth/login으로 리다이렉트되는 문제 해결을 위한 수정

---

## 🔀 병합 및 대상 브랜치

- 현재 브랜치: `feature/integration`
- 병합 대상 브랜치: `develop`

---

## ✅ 작업 내용 체크리스트

- [ ] 기능 추가
- [ ] UI/UX 개선
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서(README 등) 수정

---

## 🛠️ 작업 상세 내용

- 예: next-auth 세션 문제 해결을 위해 middleware.ts 내 getToken() 호출의 secret을 JWT_SECRET → NEXTAUTH_SECRET으로 통일
- authOptions.jwt.secret과 middleware가 동일한 secret을 사용하도록 수정
- 사용되지 않는 JWT_SECRET 환경변수 제거

---

## 🧩 기타 참고 사항
